### PR TITLE
Refactor IAM Role and IAM Policy

### DIFF
--- a/terraform/aws/modules/iam/role.tf
+++ b/terraform/aws/modules/iam/role.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "oidc_assume_role_policy" {
 
 resource "aws_iam_role" "oidc_role" {
   name               = "oidc_role"
-  assume_role_policy = data.aws_iam_policy_document.oidc_assume_role_policy
+  assume_role_policy = data.aws_iam_policy_document.oidc_assume_role_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "oidc_role_policy" {


### PR DESCRIPTION
下記を参考に3の記法に修正。

cf. https://cloudonaut.io/defining-iam-policies-with-terraform/

## 1. here document
* Terraformとかjsonの記法とかが混ざっちゃうし良くないよね

```tf
policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [...]
}
EOF
```

## 2. jsonencode
* terraform validate をしたときに typo を見つけてくれない

```tf
policy = <<EOF
{
  Version = "2012-10-17"
  Statement = [...]
}
```

## 3. aws_iam_policy_document
* this is really cool!!

```tf
data "aws_iam_policy_document" "example" {
  statement = {
    effect = "Allow"
    actions = [...]
  }
}

resource "aws_iam_policy" "example" {
  name   = "my-policy"
  policy = data.aws_iam_policy_document.example.json
}
```